### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -7,6 +7,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"net/http"
 	"time"
+	"github.com/google/uuid"
 )
 
 //-----------------------------------------------------------------------------
@@ -266,13 +267,15 @@ func (a *App) AddToPurchased(c *gin.Context) {
 func (a *App) GetWatchingCount(c *gin.Context) {
 	itemID := c.Param("item_id")
 
-	if !IsValidUUID(itemID) {
+	// Strong validation using github.com/google/uuid
+	parsedID, err := uuid.Parse(itemID)
+	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid item ID format"})
 		return
 	}
 
-	// Ensure itemID is a string for the BSON filter and cannot be interpreted as a JSON object.
-	safeItemID := itemID // enforce as string
+	// Only use the canonical string form provided by google/uuid
+	safeItemID := parsedID.String()
 
 	// Count how many users have this item in their watchlist
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
Potential fix for [https://github.com/cliveyg/poptape-lister-redux/security/code-scanning/1](https://github.com/cliveyg/poptape-lister-redux/security/code-scanning/1)

To fix this issue, ensure that no complex objects can be injected into the MongoDB query by constraining the `item_id` as strictly as possible. Given that a UUID format check is already performed, we should also ensure that `safeItemID` is strictly a string before inserting it into the filter, and ideally, avoid any possibility that a malicious user could send an alternate representation (e.g. via type confusion). A best-practice approach is to:
- Use the string value directly (NOT via conversion from an untrusted source that might be a JSON object).
- Optionally cast to `string` if any doubt exists,
- Guarantee that only a valid UUID string can reach the query.

Therefore, you should update the region around `safeItemID` assignment to ensure proper type safety, and if desired, reinforce the UUID validation with a stricter check (using e.g. a well-known library), or sanitize further by explicitly refusing values that are not valid strings.  
You may also import the widely-used `github.com/google/uuid` for future-proof validation, but the main fix here is to ensure true type safety and UUID validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
